### PR TITLE
Smilecdr 219 create encounter resource

### DIFF
--- a/hl7v2_default.json
+++ b/hl7v2_default.json
@@ -200,6 +200,11 @@
                 }
               }
             },
+            "focus": {
+              "array": [
+                {"object": {"reference": {"const": "urn:uuid:11ebe121-cfdc-4613-9bf2-983a382cfdc7"}}}
+              ]
+            },
             "source": {
               "object": {
                 "name": {"const": "SourceApp"},

--- a/hl7v2_default.json
+++ b/hl7v2_default.json
@@ -162,7 +162,8 @@
           "array": [
             {"template": "message_header_resource"},
             {"template": "organization_facility_resource"},
-            {"template": "patient_resource"}
+            {"template": "patient_resource"},
+            {"template": "encounter_resource"}
           ]
         }
       }
@@ -385,6 +386,64 @@
         }
       }
     },
+    "encounter_resource": {
+      "object": {
+        "fullUrl": {"const": "urn:uuid:11ebe121-cfdc-4613-9bf2-983a382cfdc7"},
+        "resource": {
+          "object": {
+            "resourceType": {"const": "Encounter"},
+            "identifier": {
+              "array": [
+                {
+                  "object": {
+                    "system": {"const": "https://pediatrix.com/fhir/NamingSystem/patient-demographics-update-id"},
+                    "value": {"template": "concat_mrn_facility"}
+                  }
+                },
+                {
+                  "object": {
+                    "system": {"const": "https://pediatrix.com/fhir/NamingSystem/pac-id"},
+                    "value": {"const": "pacid123"}
+                  }
+                }
+              ]
+            },
+            "status": {"const": "planned"},
+            "class": {
+              "object": {
+                "system": {"const": "http://terminology.hl7.org/CodeSystem/v3-ActCode"},
+                "code": {"const": "IMP"},
+                "display": {"const": "inpatient encounter"}
+              }
+            },
+            "subject": {
+              "object": {
+                "type": {"const": "Patient"},
+                "reference": {"const":"urn:uuid:61ebe121-abcd-4613-8bf2-983a382abcd7"}
+              }
+            },
+            "period": {
+              "object": {
+                "start": {"xpath": "PV1/admit_datetime", "template": "transform_datetime"},
+                "end": {"xpath": "PV1/discharge_datetime", "template": "transform_datetime"}
+              }
+            },
+            "serviceProvider": {
+              "object": {
+                "reference": {"const": "urn:uuid:11ebe121-cdef-4613-9bf2-983a382cdef7"}
+              }
+            }
+          }
+        },
+        "request": {
+          "object": {
+            "method": {"const": "POST"},
+            "url": {"const": "Encounter"},
+            "ifNoneExist": {"template": "encounter_conditional_post"}
+          }
+        }
+      }
+    },
     "transform_marital_code": {
         "custom_func": {
             "name": "javascript",
@@ -562,6 +621,24 @@
                 { "xpath": "MSH/datetime_of_message" }
             ]
         }
+    },
+    "concat_mrn_facility": {
+      "custom_func": {
+          "name": "concat",
+          "args": [
+              { "xpath": "PID/mrn" },
+              { "const": "-{{FacilityId}}" }
+          ]
+      }
+    },
+    "encounter_conditional_post": {
+      "custom_func": {
+          "name": "concat",
+          "args": [
+              { "const": "identifier=https://pediatrix.com/fhir/NamingSystem/patient-demographics-update-id|" },
+              { "template": "concat_mrn_facility" }
+          ]
+      }
     },
     "patient_conditional_put": {
       "custom_func": {


### PR DESCRIPTION
Encounter resource added to schema json file.

1. added unique business identifier (combination of MRN and Facility)
2. replaced encounter.plannedstartdate (it is invalid in R4) with encounter.period.start.
3. replaced encounter.plannedenddate (it is invalid in R4) with encounter.period.end.
4. removed serviceProvider element as there will be no department to reference. Facility based queries can still be executed by chaining Encounter → Patient → Facility
5. added messageheader.focus to reference the encounter urn:uuid.
6. Removed Encounter.participant references to Practitioners (referring and attending) until those are available in the schema.