### PR TITLE
Restoring Organization (Payor) changes with new push

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 output*.json
+op


### PR DESCRIPTION
The changes for Payor had been reverted previously based on an issue reported in the https://universal-etl-parser.mdnxdev.com/swagger/index.html

It, however, turned out that the issue was related to a missing carriage return at the end of IN1 segment he was using to test.

Restored the original changes with a new push.