### PR TITLE
Smilecdr 226 create related person subscriber

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 output*.json
 op
+.DS_Store

--- a/hl7v2_default.json
+++ b/hl7v2_default.json
@@ -77,6 +77,7 @@
           {"name": "DG1","min": 0},
           {"name": "GT1","min": 0,
             "elements": [
+              {"name": "set_id", "index": 1, "default": "1"},
               {"name": "guarantor_number", "index": 2, "default": "00000"},
               {"name": "last_name", "index": 3, "component_index": 1, "default": ""},
               {"name": "first_name", "index": 3, "component_index": 2, "default": ""},
@@ -128,6 +129,7 @@
                   {"name": "plan_type", "index": 15, "default": ""},
                   {"name": "insured_first_name", "index": 16, "component_index": 1, "default": ""},
                   {"name": "insured_last_name", "index": 16, "component_index": 2, "default": ""},
+                  {"name": "insured_middle_name", "index": 16, "component_index": 3, "default": ""},
                   {"name": "insured_patient_relationship", "index": 17, "default": ""},
                   {"name": "insured_address_1", "index": 19, "component_index": 1, "default": ""},
                   {"name": "insured_address_2", "index": 19, "component_index": 2, "default": ""},
@@ -170,6 +172,7 @@
             {"xpath": "PV1[not(//PV1/attending_physician_id[text()=''])]", "template": "practitioner_attending_resource"},
             {"xpath": ".[//PV1/financial_class[text()='COMM']]", "template": "account_resource", "_comment": "financial class used to determine if account resource can be generated using guarantor"},
             {"xpath": ".[//PV1/financial_class[text()='COMM']]", "template": "relatedperson_guarantor_resource", "_comment": "financial class and IN1 set 1 used to determine if guarantor relatedperson resource can be generated"},
+            {"xpath": ".[//PV1/financial_class[text()='COMM']]", "template": "relatedperson_subscriber_resource", "_comment": "financial class used to determine if subscriber relatedperson resource can be generated"},
             {"xpath": ".[//PV1/financial_class[text()='COMM']]", "template": "coverage_resource", "_comment": "financial class and IN1 set 1 used to determine if coverage resource can be generated"}
           ]
         }
@@ -475,6 +478,35 @@
                       }
                     }
                   }
+                },
+                {
+                  "object": {
+                    "type": {
+                      "array":[
+                        {
+                          "object": {
+                            "coding": {
+                              "array": [
+                                {
+                                  "object": {
+                                    "system": {"const": "http://terminology.hl7.org/CodeSystem/v3-ParticipationType"},
+                                    "code": {"const": "REF"},
+                                    "display": {"const": "Referring"}
+                                  }
+                                }
+                              ]
+                            }
+                          }
+                        }
+                      ]
+                    },
+                    "individual": {
+                      "object": {
+                        "type": {"const": "Practitioner"},
+                        "reference": {"const": "urn:uuid:11ebe121-cdef-5612-9bf2-983a381cdef6"}
+                      }
+                    }
+                  }
                 }
               ]
             }
@@ -528,7 +560,7 @@
             },
             "name": {
             "array": [
-                {
+                {"xpath": "//GT1",
                 "object": {
                     "family": {"xpath": "last_name"},
                     "given": {
@@ -551,7 +583,7 @@
             "birthDate": {"xpath": "dob", "template": "transform_date"},
             "address": {
                 "array": [
-                  {
+                  {"xpath": "//GT1",
                     "object": {
                       "use": {"xpath": "address_type", "template": "transform_address_use"},
                       "type": {"const": "physical"},
@@ -575,6 +607,96 @@
           "object": {
             "method": {"const": "PUT"},
             "url": {"template": "relatedperson_guarantor_put_request"}
+          }
+        }
+      }
+    },
+    "relatedperson_subscriber_resource": {
+      "object": {
+        "fullUrl": {"const": "urn:uuid:11ebe121-cdef-4614-9cf2-983a382cdef8"},
+        "resource": {
+          "object": {
+            "resourceType": {"const": "RelatedPerson"},
+            "identifier": {
+              "array": [
+                {
+                  "object": {
+                    "system": {"const": "https://pediatrix.com/fhir/NamingSystem/relatedPerson-id"},
+                    "value": {"template": "transform_relatedperson_subscriber_identifier"}
+                  }
+                },
+                {
+                  "object": {
+                    "system": {"const": "http://hl7.org/fhir/sid/us-ssn"},
+                    "value": {"xpath": "ssn"},
+                    "type": {
+                      "object": {
+                        "coding": {
+                          "array": [
+                            {
+                              "object": {
+                                "system": {"const": "https://terminology.hl7.org/5.0.0/CodeSystem-v2-0203"},
+                                "code": {"const": "SS"},
+                                "display": {"const": "Social Security Number"}
+                              }
+                            }
+                          ]
+                        }
+                      }
+                    }
+                  }
+                }
+              ]
+            },
+            "name": {
+            "array": [
+                {"xpath":"//IN1",
+                  "object": {
+                      "family": {"xpath": "insured_last_name"},
+                      "given": {
+                          "array": [
+                              {"xpath": "insured_first_name"},
+                              {"xpath": "insured_middle_name"}
+                          ]
+                      }
+                  }
+                }
+            ]
+            },
+            "patient": {
+              "object": {
+                "type": {"const": "Patient"},
+                "reference": {"const": "urn:uuid:61ebe121-abcd-4613-8bf2-983a382abcd7"}
+              }
+            },
+            "gender": {"xpath": "gender", "template": "transform_gender_code"},
+            "birthDate": {"xpath": "dob", "template": "transform_date"},
+            "address": {
+                "array": [
+                  {"xpath":"//IN1",
+                    "object": {
+                      "use": {"xpath": "address_type", "template": "transform_address_use"},
+                      "type": {"const": "physical"},
+                      "line": {
+                          "array": [
+                              {"xpath": "insured_address_1"},
+                              {"xpath": "insured_address_2"}
+                          ]
+                      },
+                      "city": {"xpath": "insured_city"},
+                      "state": {"xpath": "insured_state"},
+                      "postalCode": {"xpath": "insured_zip"},
+                      "country": {"xpath": "insured_country"}
+                    }
+                  }
+                ]
+            }
+          }
+        },
+        "request": {
+          "object": {
+            "method": {"const": "PUT"},
+            "url": {"template": "relatedperson_subscriber_put_request"}
           }
         }
       }
@@ -815,7 +937,7 @@
                 {
                   "object": {
                     "system": {"const": "https://pediatrix.com/fhir/NamingSystem/patientAccount-id"},
-                    "value": {"template": "concat_mrn_facility"}
+                    "value": {"template": "concat_mrn_facility_no_hyphen"}
                   }
                 }
               ]
@@ -1087,16 +1209,6 @@
             ]
         }
     },
-    "transform_relatedperson_subscriber_identifier": {
-        "custom_func": {
-            "name": "javascript",
-            "args": [
-                {"const": "insured_lname !== null && insured_fname !== null ? insured_fname + ' ' + insured_lname : ''"},
-                {"const": "insured_lname"}, {"xpath": "IN1/insured_last_name"},
-                {"const": "insured_fname"}, {"xpath": "IN1/insured_first_name"}
-            ]
-        }
-    },
     "transform_message_header_identifier": {
       "custom_func": {
           "name": "concat",
@@ -1120,9 +1232,21 @@
       "custom_func": {
           "name": "javascript",
           "args": [
-              {"const": "guarantor_number !== null ? guarantor_number : mrn_facility"},
+              {"const": "guarantor_number !== null ? mrn_facility+guarantor_number : mrn_facility+GT1+set_id"},
               {"const": "guarantor_number"}, {"xpath": "//GT1/guarantor_number"},
-              {"const": "mrn_facility"}, { "template": "concat_mrn_facility" }
+              {"const": "mrn_facility"}, { "template": "concat_mrn_facility_no_hyphen" },
+              {"const": "set_id"}, {"xpath": "//GT1/set_id"}
+          ]
+      }
+    },
+    "transform_relatedperson_subscriber_identifier": {
+      "custom_func": {
+          "name": "javascript",
+          "args": [
+              {"const": "plan_id !== null ? mrn_facility+plan_id : mrn_facility+IN1+set_id"},
+              {"const": "plan_id"}, {"xpath": "//IN1/plan_id"},
+              {"const": "mrn_facility"}, { "template": "concat_mrn_facility_no_hyphen" },
+              {"const": "set_id"}, {"xpath": "//IN1/set_id"}
           ]
       }
     },
@@ -1132,6 +1256,15 @@
           "args": [
               { "xpath": "PID/mrn" },
               { "const": "-{{FacilityId}}" }
+          ]
+      }
+    },
+    "concat_mrn_facility_no_hyphen": {
+      "custom_func": {
+          "name": "concat",
+          "args": [
+              { "xpath": "PID/mrn" },
+              { "const": "{{FacilityId}}" }
           ]
       }
     },
@@ -1160,6 +1293,15 @@
           "args": [
               { "const": "RelatedPerson?identifier=https://pediatrix.com/fhir/NamingSystem/relatedPerson-id|" },
               { "template": "transform_relatedperson_guarantor_identifier" }
+          ]
+      }
+    },
+    "relatedperson_subscriber_put_request": {
+      "custom_func": {
+          "name": "concat",
+          "args": [
+              { "const": "RelatedPerson?identifier=https://pediatrix.com/fhir/NamingSystem/relatedPerson-id|" },
+              { "template": "transform_relatedperson_subscriber_identifier" }
           ]
       }
     },
@@ -1195,7 +1337,7 @@
           "name": "concat",
           "args": [
               { "const": "Account?identifier=https://pediatrix.com/fhir/NamingSystem/patientAccount-id|" },
-              { "template": "concat_mrn_facility" }
+              { "template": "concat_mrn_facility_no_hyphen" }
           ]
       }
     },

--- a/hl7v2_default.json
+++ b/hl7v2_default.json
@@ -504,7 +504,7 @@
                     "individual": {
                       "object": {
                         "type": {"const": "Practitioner"},
-                        "reference": {"const": "urn:uuid:11ebe121-cdef-5612-9bf2-983a381cdef6"}
+                        "reference": {"const": "urn:uuid:11ebe121-cdef-5613-9bf2-983a382cdef7"}
                       }
                     }
                   }
@@ -938,7 +938,7 @@
                 {
                   "object": {
                     "system": {"const": "https://pediatrix.com/fhir/NamingSystem/patientAccount-id"},
-                    "value": {"template": "concat_mrn_facility_no_hyphen"}
+                    "value": {"template": "concat_mrn_facility"}
                   }
                 }
               ]
@@ -1289,9 +1289,9 @@
       "custom_func": {
           "name": "javascript",
           "args": [
-              {"const": "guarantor_number !== null ? mrn_facility+guarantor_number : mrn_facility+GT1+set_id"},
+              {"const": "guarantor_number !== null ? mrn_facility+'-'+guarantor_number : mrn_facility+GT1+set_id"},
               {"const": "guarantor_number"}, {"xpath": "//GT1/guarantor_number"},
-              {"const": "mrn_facility"}, { "template": "concat_mrn_facility_no_hyphen" },
+              {"const": "mrn_facility"}, { "template": "concat_mrn_facility" },
               {"const": "set_id"}, {"xpath": "//GT1/set_id"}
           ]
       }
@@ -1300,9 +1300,9 @@
       "custom_func": {
           "name": "javascript",
           "args": [
-              {"const": "plan_id !== null ? mrn_facility+plan_id : mrn_facility+IN1+set_id"},
+              {"const": "plan_id !== null ? mrn_facility+'-'+plan_id : mrn_facility+IN1+set_id"},
               {"const": "plan_id"}, {"xpath": "//IN1/plan_id"},
-              {"const": "mrn_facility"}, { "template": "concat_mrn_facility_no_hyphen" },
+              {"const": "mrn_facility"}, { "template": "concat_mrn_facility" },
               {"const": "set_id"}, {"xpath": "//IN1/set_id"}
           ]
       }
@@ -1313,15 +1313,6 @@
           "args": [
               { "xpath": "PID/mrn" },
               { "const": "-{{FacilityId}}" }
-          ]
-      }
-    },
-    "concat_mrn_facility_no_hyphen": {
-      "custom_func": {
-          "name": "concat",
-          "args": [
-              { "xpath": "PID/mrn" },
-              { "const": "{{FacilityId}}" }
           ]
       }
     },
@@ -1394,7 +1385,7 @@
           "name": "concat",
           "args": [
               { "const": "Account?identifier=https://pediatrix.com/fhir/NamingSystem/patientAccount-id|" },
-              { "template": "concat_mrn_facility_no_hyphen" }
+              { "template": "concat_mrn_facility" }
           ]
       }
     },


### PR DESCRIPTION
1. Added “relatedperson_subscriber_resource” to the hl7v2_default.json schema/template file.
2. Added Encounter.participant reference to referring Practitioner.
Per Jason recommendations - 
3. RelatedPerson guarantor business identifier will be mrn-facilityid-guarantor_number (when guarantor_number exists, else mrn-facilityid-GT1<setid>)
4. RelatedPerson guarantor business identifier set to mrn-facilityid-plan_id (when plan_id exists, else mrn-facilityid-IN1<setid>)