### PR TITLE
SMILECDR-265 identifier urls cannot have spaces

### DIFF
--- a/hl7v2_default.json
+++ b/hl7v2_default.json
@@ -1447,7 +1447,7 @@
         "custom_func": {
             "name": "javascript",
             "args": [
-                {"const": "!policy_number || policy_number == '' ? mrnfacility + '-IN1-' + setid.toString() : mrnfacility + '-' + policy_number"},
+                {"const": "!policy_number || policy_number == '' ? mrnfacility + '-IN1-' + setid.toString() : mrnfacility + '-' + encodeURIComponent(policy_number).replace(/\\%[A-F0-9]{2}/g,'')"},
                 {"const": "policy_number"}, {"xpath": "policy_number"},
                 {"const": "setid"}, {"xpath": "set_id", "template": "transform_insurance_set_id"},
                 {"const": "mrnfacility"}, {"xpath": "../..", "template": "concat_mrn_facility", "_comment": "IN1 passed in, navigate to root so PID can be referenced"}
@@ -1458,7 +1458,7 @@
         "custom_func": {
             "name": "javascript",
             "args": [
-                {"const": "!npi || npi == '' ? mrnfacility + '-PV1-' + idtype : mrnfacility + '-' + npi"},
+                {"const": "!npi || npi == '' ? mrnfacility + '-PV1-' + idtype : mrnfacility + '-' + encodeURIComponent(npi).replace(/\\%[A-F0-9]{2}/g,'')"},
                 {"const": "npi"}, {"xpath": "attending_physician_id"},
                 {"const": "idtype"}, {"const": "ATND"},
                 {"const": "mrnfacility"}, {"xpath": "..", "template": "concat_mrn_facility"}
@@ -1469,7 +1469,7 @@
         "custom_func": {
             "name": "javascript",
             "args": [
-                {"const": "!npi || npi == '' ? mrnfacility + '-PV1-' + idtype : mrnfacility + '-' + npi"},
+                {"const": "!npi || npi == '' ? mrnfacility + '-PV1-' + idtype : mrnfacility + '-' + encodeURIComponent(npi).replace(/\\%[A-F0-9]{2}/g,'')"},
                 {"const": "npi"}, {"xpath": "referring_physician_id"},
                 {"const": "idtype"}, {"const": "REF"},
                 {"const": "mrnfacility"}, {"xpath": "..", "template": "concat_mrn_facility"}
@@ -1517,7 +1517,7 @@
       "custom_func": {
           "name": "javascript",
           "args": [
-            {"const": "!guarantornumber || guarantornumber == '' ? mrnfacility + '-GT1-' + setid.toString() : mrnfacility + '-' + guarantornumber"},
+            {"const": "!guarantornumber || guarantornumber == '' ? mrnfacility + '-GT1-' + setid.toString() : mrnfacility + '-' + encodeURIComponent(guarantornumber).replace(/\\%[A-F0-9]{2}/g,'')"},
             {"const": "guarantornumber"}, {"xpath": "guarantor_number"},
             {"const": "setid"}, {"xpath": "set_id", "template": "transform_guarantor_set_id"},
             {"const": "mrnfacility"}, {"xpath": "../..", "template": "concat_mrn_facility"}
@@ -1528,7 +1528,7 @@
       "custom_func": {
           "name": "javascript",
           "args": [
-            {"const": "!planid || planid == '' ? mrnfacility + '-IN1-' + setid.toString() : mrnfacility + '-' + planid"},
+            {"const": "!planid || planid == '' ? mrnfacility + '-IN1-' + setid.toString() : mrnfacility + '-' + encodeURIComponent(planid).replace(/\\%[A-F0-9]{2}/g,'')"},
             {"const": "planid"}, {"xpath": "plan_id"},
             {"const": "setid"}, {"xpath": "set_id", "template": "transform_insurance_set_id"},
             {"const": "mrnfacility"}, {"xpath": "../..", "template": "concat_mrn_facility"}

--- a/hl7v2_default_test.json
+++ b/hl7v2_default_test.json
@@ -1447,7 +1447,7 @@
         "custom_func": {
             "name": "javascript",
             "args": [
-                {"const": "!policy_number || policy_number == '' ? mrnfacility + '-IN1-' + setid.toString() : mrnfacility + '-' + policy_number"},
+                {"const": "!policy_number || policy_number == '' ? mrnfacility + '-IN1-' + setid.toString() : mrnfacility + '-' + encodeURIComponent(policy_number).replace(/\\%[A-F0-9]{2}/g,'')"},
                 {"const": "policy_number"}, {"xpath": "policy_number"},
                 {"const": "setid"}, {"xpath": "set_id", "template": "transform_insurance_set_id"},
                 {"const": "mrnfacility"}, {"xpath": "../..", "template": "concat_mrn_facility", "_comment": "IN1 passed in, navigate to root so PID can be referenced"}
@@ -1458,7 +1458,7 @@
         "custom_func": {
             "name": "javascript",
             "args": [
-                {"const": "!npi || npi == '' ? mrnfacility + '-PV1-' + idtype : mrnfacility + '-' + npi"},
+                {"const": "!npi || npi == '' ? mrnfacility + '-PV1-' + idtype : mrnfacility + '-' + encodeURIComponent(npi).replace(/\\%[A-F0-9]{2}/g,'')"},
                 {"const": "npi"}, {"xpath": "attending_physician_id"},
                 {"const": "idtype"}, {"const": "ATND"},
                 {"const": "mrnfacility"}, {"xpath": "..", "template": "concat_mrn_facility"}
@@ -1469,7 +1469,7 @@
         "custom_func": {
             "name": "javascript",
             "args": [
-                {"const": "!npi || npi == '' ? mrnfacility + '-PV1-' + idtype : mrnfacility + '-' + npi"},
+                {"const": "!npi || npi == '' ? mrnfacility + '-PV1-' + idtype : mrnfacility + '-' + encodeURIComponent(npi).replace(/\\%[A-F0-9]{2}/g,'')"},
                 {"const": "npi"}, {"xpath": "referring_physician_id"},
                 {"const": "idtype"}, {"const": "REF"},
                 {"const": "mrnfacility"}, {"xpath": "..", "template": "concat_mrn_facility"}
@@ -1517,7 +1517,7 @@
       "custom_func": {
           "name": "javascript",
           "args": [
-            {"const": "!guarantornumber || guarantornumber == '' ? mrnfacility + '-GT1-' + setid.toString() : mrnfacility + '-' + guarantornumber"},
+            {"const": "!guarantornumber || guarantornumber == '' ? mrnfacility + '-GT1-' + setid.toString() : mrnfacility + '-' + encodeURIComponent(guarantornumber).replace(/\\%[A-F0-9]{2}/g,'')"},
             {"const": "guarantornumber"}, {"xpath": "guarantor_number"},
             {"const": "setid"}, {"xpath": "set_id", "template": "transform_guarantor_set_id"},
             {"const": "mrnfacility"}, {"xpath": "../..", "template": "concat_mrn_facility"}
@@ -1528,7 +1528,7 @@
       "custom_func": {
           "name": "javascript",
           "args": [
-            {"const": "!planid || planid == '' ? mrnfacility + '-IN1-' + setid.toString() : mrnfacility + '-' + planid"},
+            {"const": "!planid || planid == '' ? mrnfacility + '-IN1-' + setid.toString() : mrnfacility + '-' + encodeURIComponent(planid).replace(/\\%[A-F0-9]{2}/g,'')"},
             {"const": "planid"}, {"xpath": "plan_id"},
             {"const": "setid"}, {"xpath": "set_id", "template": "transform_insurance_set_id"},
             {"const": "mrnfacility"}, {"xpath": "../..", "template": "concat_mrn_facility"}


### PR DESCRIPTION
Modified 'transform' logic for identifiers in the following resources:
1. Coverage
2. RelatedPerson (subscriber, guarantor)
3. Practitioner (attending, referring)