### PR TITLE
Push to prod for Invalid PD1 after PV2 and NTE after OBX

### DIFF
--- a/hl7v2_default.json
+++ b/hl7v2_default.json
@@ -92,6 +92,7 @@
         {"name": "ROL","min": 0, "max": -1},
         {"name": "DB1","min": 0, "max": -1},
         {"name": "OBX","min": 0, "max": -1},
+        {"name": "NTE","min": 0, "max": -1},
         {"name": "allergy", "type":"segment_group","min": 0, "max": -1,
             "child_segments": [
                 {"name": "AL1","min": 0,"max": -1},

--- a/hl7v2_default.json
+++ b/hl7v2_default.json
@@ -84,6 +84,7 @@
             ]
         },
         {"name": "PV2","min": 0, "max": -1},
+        {"name": "PD1","min": 0, "max": -1},
         {"name": "ZPV","min": 0, "max": -1},
         {"name": "ZVI","min": 0, "max": -1},
         {"name": "ZIF","min": 0, "max": -1},

--- a/hl7v2_default_test.json
+++ b/hl7v2_default_test.json
@@ -92,6 +92,7 @@
         {"name": "ROL","min": 0, "max": -1},
         {"name": "DB1","min": 0, "max": -1},
         {"name": "OBX","min": 0, "max": -1},
+        {"name": "NTE","min": 0, "max": -1},
         {"name": "allergy", "type":"segment_group","min": 0, "max": -1,
             "child_segments": [
                 {"name": "AL1","min": 0,"max": -1},

--- a/hl7v2_default_test.json
+++ b/hl7v2_default_test.json
@@ -84,6 +84,7 @@
             ]
         },
         {"name": "PV2","min": 0, "max": -1},
+        {"name": "PD1","min": 0, "max": -1},
         {"name": "ZPV","min": 0, "max": -1},
         {"name": "ZVI","min": 0, "max": -1},
         {"name": "ZIF","min": 0, "max": -1},


### PR DESCRIPTION
1. Jason has made changes in  hl7v2_default.json and  hl7v2_default_test.jsonfiles for Invalid/missing PD1 after PV2 and Invalid/missing NTE after OBX
2. Anil completed validations in Smile. For reference please refer, https://mednax1500.atlassian.net/browse/SMILECDR-302