### PR TITLE
PDIP-56 Add NTE optional segment (after PD1: Piedmont)

### DIFF
--- a/hl7v2_default.json
+++ b/hl7v2_default.json
@@ -60,6 +60,7 @@
         {"name": "NTE","min": 0, "max": -1},
         {"name": "ZPD","min": 0, "max": -1},
         {"name": "PD1","min": 0, "max": -1},
+        {"name": "NTE","min": 0, "max": -1},
         {"name": "ZPI","min": 0, "max": -1},
         {"name": "ZEI","min": 0, "max": -1},
         {"name": "MRG","min": 0, "max": -1},

--- a/hl7v2_default_test.json
+++ b/hl7v2_default_test.json
@@ -60,6 +60,7 @@
         {"name": "NTE","min": 0, "max": -1},
         {"name": "ZPD","min": 0, "max": -1},
         {"name": "PD1","min": 0, "max": -1},
+        {"name": "NTE","min": 0, "max": -1},
         {"name": "ZPI","min": 0, "max": -1},
         {"name": "ZEI","min": 0, "max": -1},
         {"name": "MRG","min": 0, "max": -1},


### PR DESCRIPTION
1) Jason added PDIP-56 Add NTE optional segment (after PD1: Piedmont)
2) Anil completed validations in Smile. For reference, https://mednax1500.atlassian.net/browse/SMILECDR-306