### PR TITLE
Remove conditional for returning lines

### DIFF
--- a/edi_271.json
+++ b/edi_271.json
@@ -232,6 +232,11 @@
                                                     "index": 3,
                                                     "name": "service_type_code",
                                                     "default": ""
+                                                  },
+                                                  {
+                                                    "index": 5,
+                                                    "name": "plan_coverage_description",
+                                                    "default": ""
                                                   }
                                                 ]
                                               },
@@ -425,6 +430,11 @@
                                                             "index": 3,
                                                             "name": "service_type_code",
                                                             "default": ""
+                                                          },
+                                                          {
+                                                            "index": 5,
+                                                            "name": "plan_coverage_description",
+                                                            "default": ""
                                                           }
                                                         ]
                                                       },
@@ -605,6 +615,9 @@
                 },
                 "service_type_code": {
                   "xpath": "service_type_code"
+                },
+                "plan_coverage_description": {
+                  "xpath": "plan_coverage_description"
                 }
               }
             }
@@ -620,6 +633,9 @@
                 },
                 "service_type_code": {
                   "xpath": "service_type_code"
+                },
+                "plan_coverage_description": {
+                  "xpath": "plan_coverage_description"
                 }
               }
             }

--- a/pmd_to_obr_charges.json
+++ b/pmd_to_obr_charges.json
@@ -1,7 +1,8 @@
 {
   "parser_settings": {
     "version": "omni.2.1",
-    "file_format_type": "csv2"
+    "file_format_type": "csv2",
+    "debug": 1
   },
   "file_declaration": {
     "delimiter": ",",
@@ -153,8 +154,10 @@
   },
   "transform_declarations": {
     "FINAL_OUTPUT": {
-      "xpath": ".[string-length(hospital_code) < 5]",
       "object": {
+        "line_num": {
+          "xpath": "__debug/line_num"
+        },
         "hospital_code": {
           "xpath": "hospital_code"
         },

--- a/pmd_to_obr_charges.json
+++ b/pmd_to_obr_charges.json
@@ -1,8 +1,7 @@
 {
   "parser_settings": {
     "version": "omni.2.1",
-    "file_format_type": "csv2",
-    "debug": 1
+    "file_format_type": "csv2"
   },
   "file_declaration": {
     "delimiter": ",",
@@ -155,9 +154,6 @@
   "transform_declarations": {
     "FINAL_OUTPUT": {
       "object": {
-        "line_num": {
-          "xpath": "__debug/line_num"
-        },
         "hospital_code": {
           "xpath": "hospital_code"
         },


### PR DESCRIPTION
Removing conditional for bad csv lines and having the application log + handle it. This will help to debug in the future and make sure that we are not loosing any csv data after being parsed.