### PR TITLE
SMILECDR-1298: Add a condition for the maritalStatus element on the P…

### DIFF
--- a/hl7v2_default_test.json
+++ b/hl7v2_default_test.json
@@ -573,7 +573,7 @@
                 }
               ]
             },
-            "maritalStatus": {"xpath": ".[PID/marital_status!='']",
+            "maritalStatus": {"xpath": ".[transform_marital_code!='']",
               "object": {
                 "coding": {
                   "array": [


### PR DESCRIPTION
[SMILECDR-1298](https://mednax1500.atlassian.net/browse/SMILECDR-1298)

The main scope of this change ensures that the maritalStatus element will only be included if the transformed value is not empty. The transform_marital_code transformation will be applied first to PID/marital_status. If it results in a non-empty value (e.g., "M" for "Married"), the maritalStatus element will be generated.